### PR TITLE
bump versions and use substrate github

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,8 +101,7 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35391ea974fa5ee869cb094d5b437688fbf3d8127d64d1b9fed5822a1ed39b12"
+source = "git+https://github.com/paritytech/substrate#4e75f511e1357cf54c31d9e82d0cf3e39a2b8c28"
 
 [[package]]
 name = "spin"
@@ -125,8 +124,6 @@ dependencies = [
 [[package]]
 name = "substrate-stellar-xdr"
 version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d258a08d467d492bcaab0414be2a0570deb2f14bf27b8ca29e00fdbe217396"
 dependencies = [
  "base64",
  "sp-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-stellar-sdk"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Torsten Stüber <torsten@satoshipay.io>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ keywords = ["substrate", "Stellar"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sp-std = { default-features = false, version = "3.0.0" }
-substrate-stellar-xdr = { version = "0.2.6" }
+sp-std = { default-features = false, git = "https://github.com/paritytech/substrate" }
+substrate-stellar-xdr = "2.0.7"
 sodalite = { version = "0.4.0" }
 sha2 = { default-features = false, version = "0.9.5" }
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }


### PR DESCRIPTION
Depends on the merging and releasing of pendulum-chain/substrate-stellar-xdr-generator#1

**need deployment to crates.io**
