### PR TITLE
fix unresolved import `sp_core::to_substrate_wasm_fn_return_value`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ exclude = ["autogenerator/*"]
 serde_json = { version = '1.0.64', default-features = false, features = ["alloc"], optional = true }
 serde = { version = "1.0.100", default-features = false, features = ["derive", "alloc"], optional = true }
 hex = { version = "0.4", default-features = false}
-sp-std = { version = "4.0.0", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24" }
-sp-runtime = { version = "6.0.0", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24", optional = true }
-sp-io = { version = "6.0.0", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24", optional = true }
+sp-std = { version = "4.0.0", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.24" }
+sp-runtime = { version = "6.0.0", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.24", optional = true }
+sp-io = { version = "6.0.0", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.24", optional = true }
 sodalite = { version = "0.4.0" }
 sha2 = { default-features = false, version = "0.9.9" }
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }


### PR DESCRIPTION
```
 error[E0432]: unresolved import `sp_core::to_substrate_wasm_fn_return_value`
    --> /home/.cargo/git/checkouts/substrate-7e08433d4c370a21/814752f/primitives/api/src/lib.rs:80:9
     |
  80 | pub use sp_core::to_substrate_wasm_fn_return_value;
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `to_substrate_wasm_fn_return_value` in the root
```

^ The error occurs when std libraries are used for no_std substrate code.  This will help https://github.com/pendulum-chain/spacewalk/issues/75.