### PR TITLE
public `get_hash` for hashing a tx

### DIFF
--- a/src/xdr/impls/transaction_envelope.rs
+++ b/src/xdr/impls/transaction_envelope.rs
@@ -114,7 +114,7 @@ impl TransactionEnvelope {
         Ok(())
     }
 
-    fn get_hash(&self, network: &Network) -> BinarySha256Hash {
+    pub fn get_hash(&self, network: &Network) -> BinarySha256Hash {
         let network_id = network.get_id().clone();
 
         let tagged_transaction = match self {


### PR DESCRIPTION
which is used as key for storing externalized messages.
see https://github.com/pendulum-chain/spacewalk/issues/85