### PR TITLE
Expose DecodeError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ pub use xdr::{
 pub use xdr::impls::transaction_set_type::*;
 
 pub use utils::std::StellarTypeToString;
-
+pub use utils::key_encoding::*;
 pub use amount::*;
 pub use binary::*;
 pub use public_key::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ pub use xdr::{
         account_id::IntoAccountId, claimable_balance_id::IntoClaimbleBalanceId, data_value::IntoDataValue,
         hash::IntoHash, muxed_account::IntoMuxedAccountId, time_bounds::*,
     },
-    streams::{ReadStream, WriteStream},
+    streams::{ReadStream, WriteStream, DecodeError},
     types::{
         self, AccountId, Asset, AssetCode, ClaimPredicate, ClaimableBalanceId, Claimant, Curve25519Secret, DataValue,
         FeeBumpTransaction, Hash, LedgerKey, Memo, MuxedAccount, Operation, Price, PublicKey, Signer, SignerKey,


### PR DESCRIPTION
I've been using this SDK in [my Stellar node connector](https://github.com/grandima/stellar-handshake) in Rust and It seems like `StellarSdkError` is exposed but for some reason `DecodeError` is not. I haven't understood the reason why not exposing this error so I've created this PR.