### PR TITLE
Avoid specifying sp version directly. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["autogenerator/*"]
 serde_json = { version = '1.0.64', default-features = false, features = ["alloc"], optional = true }
 serde = { version = "1.0.136", default-features = false, features = ["derive", "alloc"], optional = true }
 hex = { version = "0.4", default-features = false , features = ["alloc"]}
-sodalite = { version = "0.4.0" }
+sodalite = { version = "0.4.0", default-features = false }
 sha2 = { default-features = false, version = "0.10.8" }
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 base64 = { default-features = false, version = "0.13.0" }
@@ -22,9 +22,9 @@ num-rational = {version = "0.4", default-features = false}
 scale-info = {version = "2.1.1", default-features = false, features = ["derive"]}
 
 # Substrate
-sp-std = { version = "8.0.0", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
-sp-runtime = { version = "24.0.0", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false, optional = true }
-sp-io = { version = "23.0.0", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false, optional = true }
+sp-std = {  git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false, optional = true }
+sp-io = {  git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", default-features = false, optional = true }
 
 [features]
 default = [ "offchain", "std" ]


### PR DESCRIPTION
Required for properly compiling pendulum runtimes for the [update](https://github.com/pendulum-chain/pendulum/pull/489).