### PR TITLE
conversion to base64 string

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,16 @@ mod lib {
     #[cfg(not(feature = "std"))]
     pub use alloc::string::{FromUtf8Error, String, ToString};
 
+    #[cfg(not(feature = "std"))]
+    pub use alloc::format;
+
     #[cfg(feature = "std")]
     #[allow(unused_imports)]
     pub use std::string::{FromUtf8Error, String, ToString};
+
+    #[cfg(feature = "std")]
+    #[allow(unused_imports)]
+    pub use std::format;
 }
 
 mod amount;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,16 +10,9 @@ mod lib {
     #[cfg(not(feature = "std"))]
     pub use alloc::string::{FromUtf8Error, String, ToString};
 
-    #[cfg(not(feature = "std"))]
-    pub use alloc::format;
-
     #[cfg(feature = "std")]
     #[allow(unused_imports)]
     pub use std::string::{FromUtf8Error, String, ToString};
-
-    #[cfg(feature = "std")]
-    #[allow(unused_imports)]
-    pub use std::format;
 }
 
 mod amount;

--- a/src/utils/std.rs
+++ b/src/utils/std.rs
@@ -1,4 +1,4 @@
-use crate::lib::{String, format};
+use crate::lib::String;
 use crate::XdrCodec;
 
 /// A trait used to convert any Stellar specific type `T` as a String
@@ -20,6 +20,7 @@ pub trait StellarTypeToBase64String {
 impl <T: XdrCodec> StellarTypeToBase64String for T {
     fn as_base64_encoded_string(&self) -> String {
         let xdr = self.to_base64_xdr();
-        String::from_utf8(xdr.clone()).unwrap_or(format!("{:?}", xdr))
+        // safe to use `unwrap`, since `to_base64_xdr()` will always return a valid vec of
+        String::from_utf8(xdr.clone()).unwrap()
     }
 }

--- a/src/utils/std.rs
+++ b/src/utils/std.rs
@@ -1,4 +1,5 @@
-use crate::lib::String;
+use crate::lib::{String, format};
+use crate::XdrCodec;
 
 /// A trait used to convert any Stellar specific type `T` as a String
 /// This also immediately converts the standard Error to a user-defined Error `E`
@@ -8,4 +9,17 @@ use crate::lib::String;
 ///  * a `Vec<u8>` version of th Stellar type
 pub trait StellarTypeToString<T, E: From<sp_std::str::Utf8Error>> {
     fn as_encoded_string(&self) -> Result<String, E>;
+}
+
+/// A trait used to convert a structure into Base64 String
+pub trait StellarTypeToBase64String {
+    /// returns a Base64 encoded String or a vec of bytes [xdr]
+    fn as_base64_encoded_string(&self) -> String;
+}
+
+impl <T: XdrCodec> StellarTypeToBase64String for T {
+    fn as_base64_encoded_string(&self) -> String {
+        let xdr = self.to_base64_xdr();
+        String::from_utf8(xdr.clone()).unwrap_or(format!("{:?}", xdr))
+    }
 }


### PR DESCRIPTION
Move implementation of 
https://github.com/pendulum-chain/spacewalk/blob/7c7989875e95e1cfe3b0aeba9bb6af01d9e33e58/clients/stellar-relay-lib/src/connection/helper.rs#L39-L42
```
pub fn to_base64_xdr_string<T: XdrCodec>(msg: &T) -> String {
	let xdr = msg.to_base64_xdr();
	String::from_utf8(xdr.clone()).unwrap_or(format!("{:?}", xdr))
}
```

to this repo

Cleanup of https://github.com/pendulum-chain/spacewalk/pull/545 