### PR TITLE
Fix issue returning empty transaction sets for Stellar protocol v23

### DIFF
--- a/src/xdr/impls/generalized_transaction_set.rs
+++ b/src/xdr/impls/generalized_transaction_set.rs
@@ -43,7 +43,7 @@ impl GeneralizedTransactionSet {
 
         for phase in txset_v1.phases.get_vec() {
             let TransactionPhase::V0(txsets_comp) = phase else {
-                return None;
+                continue;
             };
 
             for TxSetComponent::TxsetCompTxsMaybeDiscountedFee(discounted_txs_set) in txsets_comp.get_vec() {


### PR DESCRIPTION
With Stellar core v23, the transaction set also contains `TransactionPhase::V1` elements, which currently if present, will lead to the `txes()` function returning `None` instead of the transactions that are available on the other `TransactionPhase::V0` element.